### PR TITLE
Feature/transaction

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %%-*- mode: erlang -*-
 
 {deps, [
-        {poolboy, ".*", {git, "git://github.com/devinus/poolboy.git", {tag, "1.1.0"}}},
+        {poolboy, ".*", {git, "git://github.com/devinus/poolboy.git", "master"}},
         {epgsql, ".*", {git, "git://github.com/wg/epgsql", "3318bd5d64"}},
         {tq_db, "0.5.*", {git, "git://github.com/egobrain/tq_db.git", {tag, "0.5.1"}}}
        ]}.

--- a/src/tq_postgres_driver.erl
+++ b/src/tq_postgres_driver.erl
@@ -81,7 +81,7 @@ escape_arg({Name, Arg}) when
         Bin when is_binary(Bin) ->
             try
                 {ok, binary_to_integer(Bin)}
-            catch _ ->
+            catch _:_ ->
                     {error, bad_arg}
             end;
         Int when is_integer(Int) ->
@@ -97,10 +97,10 @@ escape_arg({Name, Arg}) when
         Bin when is_binary(Bin) ->
             try
                 {ok, binary_to_integer(Bin)}
-            catch _ ->
+            catch _:_ ->
                     try
                         {ok, binary_to_float(Bin)}
-                    catch _ ->
+                    catch _:_ ->
                             {error, bad_arg}
                     end
             end;

--- a/src/tq_postgres_driver.erl
+++ b/src/tq_postgres_driver.erl
@@ -121,6 +121,13 @@ escape_arg({Name, Arg}) when
         _ ->
             {error, bad_arg}
     end;
+escape_arg({date, Arg}) ->
+    case Arg of
+        {_Y, _M, _D} ->
+            {ok, Arg};
+        _ ->
+            {error, bad_arg}
+    end;
 escape_arg({datetime, Arg}) ->
     case Arg of
         {{_Y, _M, _D}, {_Hh, _Mm, _Ss}} ->

--- a/src/tq_postgres_driver.erl
+++ b/src/tq_postgres_driver.erl
@@ -5,6 +5,8 @@
 -export([
          start_pool/3,
 
+         'squery'/2,
+         'squery'/3,
          'query'/4,
          'parse'/2,
 
@@ -28,6 +30,18 @@ start_pool(PoolName, SizeArgs, WorkerArgs) ->
         ],
     Spec = poolboy:child_spec(PoolName, PoolArgs, WorkerArgs),
     supervisor:start_child(tq_postgres_driver_sup, Spec).
+
+'squery'(PoolName, Sql) ->
+    Constructor = fun(A) -> A end,
+    'squery'(PoolName, Sql, Constructor).
+
+'squery'(PoolName, Sql, Constructor) ->
+    poolboy:transaction(
+        PoolName,
+        fun(Worker) ->
+            tq_postgres_driver_worker:'squery'(
+                Worker, Sql, Constructor)
+        end).
 
 'query'(PoolName, Sql, Args, Constructor) ->
     case escape_args(Args) of

--- a/src/tq_postgres_driver.erl
+++ b/src/tq_postgres_driver.erl
@@ -159,5 +159,5 @@ error_writer_map(Fun, [{Type, Value}=H|T], Acc, Errors) ->
         {ok, R} ->
             error_writer_map(Fun, T, [R|Acc], Errors);
         {error, R} ->
-            error_writer_map(Fun, T, Acc, [{Type, Value, R}|Errors])
+            error_writer_map(Fun, T, Acc, [{R, [Type, Value]}|Errors])
     end.

--- a/src/tq_postgres_driver.erl
+++ b/src/tq_postgres_driver.erl
@@ -3,7 +3,7 @@
 -include_lib("epgsql/include/pgsql.hrl").
 
 -export([
-         start_pool/2,
+         start_pool/3,
 
          'query'/4,
          'parse'/2,
@@ -19,14 +19,14 @@
 %% API functions
 %% =============================================================================
 
-start_pool(PoolName, Opts) ->
+start_pool(PoolName, SizeArgs, WorkerArgs) ->
     PoolArgs =
         [
          {name, {local, PoolName}},
          {worker_module, tq_postgres_driver_worker}
-         | Opts
+         | SizeArgs
         ],
-    Spec = poolboy:child_spec(PoolName, PoolArgs, Opts),
+    Spec = poolboy:child_spec(PoolName, PoolArgs, WorkerArgs),
     supervisor:start_child(tq_postgres_driver_sup, Spec).
 
 'query'(PoolName, Sql, Args, Constructor) ->

--- a/src/tq_postgres_driver_db_query.erl
+++ b/src/tq_postgres_driver_db_query.erl
@@ -1,0 +1,85 @@
+%%%-------------------------------------------------------------------
+%%% @author isergey
+%%% @copyright (C) 2015, <COMPANY>
+%%% @doc
+%%%
+%%% @end
+%%% Created : 02. Feb 2015 9:31 AM
+%%%-------------------------------------------------------------------
+-module(tq_postgres_driver_db_query).
+-author("isergey").
+
+%% API
+-export([query/4, squery/3, transaction/2]).
+-include_lib("../../epgsql/include/pgsql.hrl").
+
+query(Conn, Sql, EscapedArgs, Constructor) ->
+    case pgsql:equery(Conn, Sql, EscapedArgs) of
+        {ok, Count} when is_integer(Count) ->
+            {ok, Count};
+        {ok, _Columns, Rows} ->
+            {ok, [Constructor(tuple_to_list(R)) || R <- Rows]};
+        {ok, Count, _Columns, Rows} ->
+            {ok, Count, [Constructor(tuple_to_list(R)) || R <- Rows]};
+        {error, Reason} ->
+            Reason2 = transform_error(Sql, EscapedArgs, Reason),
+            {error, Reason2}
+    end.
+
+squery(Conn, Sql, Constructor)->
+    case pgsql:squery(Conn, Sql) of
+        {ok, Count} when is_integer(Count) ->
+            {ok, Count};
+        {ok, _Columns, Rows} ->
+            {ok, [Constructor(tuple_to_list(R)) || R <- Rows]};
+        {ok, Count, _Columns, Rows} ->
+            {ok, Count, [Constructor(tuple_to_list(R)) || R <- Rows]};
+        {error, Reason} ->
+            Reason2 = transform_error(Sql, Reason),
+            {error, Reason2};
+        List when is_list(List) ->
+            lists:foldl(fun transform_answer/2, ok, List)
+    end.
+
+transaction(Conn, Fun) ->
+    pgsql:with_transaction(Conn, Fun).
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+transform_answer(X, Answer) ->
+    case X of
+        {ok, _} -> Answer;
+        {error, Reason} ->
+            Reason2 = transform_error(Reason),
+            [{error, Reason2}|Answer]
+    end.
+
+transform_error(_Sql, _Args, #error{code = <<"23505">>}) ->
+    not_unique;
+transform_error(Sql, Args, Error) ->
+    {db_error,
+        [
+            {code, Error#error.code},
+            {message, Error#error.message},
+            {extra, Error#error.extra},
+            {sql, Sql},
+            {args, Args}
+        ]}.
+
+transform_error(Error) ->
+    {db_error,
+        [
+            {code, Error#error.code},
+            {message, Error#error.message},
+            {extra, Error#error.extra}
+        ]}.
+
+transform_error(Sql, Error) ->
+    {db_error,
+        [
+            {code, Error#error.code},
+            {message, Error#error.message},
+            {extra, Error#error.extra},
+            {sql, Sql}
+        ]}.

--- a/src/tq_postgres_driver_runtime.erl
+++ b/src/tq_postgres_driver_runtime.erl
@@ -67,12 +67,12 @@ find(PoolName, Module, Query, QueryArgs) ->
 
 delete(PoolName, Module, IndexFV) ->
     Table = Module:'$meta'(table),
-    {<<$,, Where/binary>>, _} =
+    {<<" AND ", Where/binary>>, _} =
         each_with(
           fun({F, _V}, I, Acc) ->
                   Alias = Module:'$meta'({db_alias, F}),
                   BinIndex = integer_to_binary(I),
-                  <<Acc/binary, $,, Alias/binary, " = $", BinIndex/binary>>
+                  <<Acc/binary, " AND ", Alias/binary, " = $", BinIndex/binary>>
           end, <<>>, IndexFV),
     Sql =
         <<"DELETE FROM ", Table/binary,

--- a/src/tq_postgres_driver_runtime.erl
+++ b/src/tq_postgres_driver_runtime.erl
@@ -12,7 +12,27 @@
 %% Api
 %% =============================================================================
 
-get(PoolName, Module, IndexFV) ->
+get(PoolName, Module, IndexFV) when is_atom(PoolName) or is_binary(PoolName) ->
+    {Sql, Args, Constructor} = get_params(Module, IndexFV),
+    Result = tq_postgres_driver:'query'(PoolName, Sql, Args, Constructor),
+    get_result(Result);
+
+get(Connection, Module, IndexFV) when is_pid(Connection) ->
+    {Sql, Args, Constructor} = get_params(Module, IndexFV),
+    Result = query_with_escape(Connection, Sql, Args, Constructor),
+    get_result(Result).
+
+get_result(Result) ->
+    case Result of
+        {ok, [R]} ->
+            {ok, R};
+        {ok, []} ->
+            {error, undefined};
+        {error, _Reason} = Err ->
+            Err
+    end.
+
+get_params(Module, IndexFV) ->
     Table = Module:'$meta'(table),
 
     RFields = Module:'$meta'({db_fields, r}),
@@ -33,24 +53,32 @@ get(PoolName, Module, IndexFV) ->
           " FROM ", Table/binary,
           " WHERE ", Where/binary, ";">>,
     Args = [{Module:'$meta'({db_type, F}), V} || {F, V} <- IndexFV],
-    case tq_postgres_driver:'query'(PoolName, Sql, Args, Constructor) of
-        {ok, [R]} ->
-            {ok, R};
-        {ok, []} ->
-            {error, undefined};
+    {Sql, Args, Constructor}.
+
+find(PoolName, Module, Query, QueryArgs) when is_atom(PoolName) or is_binary(PoolName) ->
+    case find_params(Module, Query, QueryArgs) of
+        {Sql, Args, Constructor} ->
+            tq_postgres_driver:'query'(PoolName, Sql, Args, Constructor);
+        {error, _Reason} = Err ->
+            Err
+    end;
+
+find(Connection, Module, Query, QueryArgs) when is_pid(Connection) ->
+    case find_params(Module, Query, QueryArgs) of
+        {Sql, Args, Constructor} ->
+            query_with_escape(Connection, Sql, Args, Constructor);
         {error, _Reason} = Err ->
             Err
     end.
 
-find(PoolName, Module, Query, QueryArgs) ->
-    Table = Module:'$meta'(table),
-    RFields = Module:'$meta'({db_fields, r}),
-    <<$,, Fields/binary>> =
-        << <<$,, Table/binary, $., (Module:'$meta'({db_alias, F}))/binary>>
-           || F <- RFields>>,
-    Constructor = Module:constructor(RFields),
+find_params(Module, Query, QueryArgs) ->
     case tq_postgres_driver_dsl:parse(Module, Query) of
         {ok, {Where, _Fields, ArgFuns}} ->
+            Table = Module:'$meta'(table),
+            RFields = Module:'$meta'({db_fields, r}),
+            <<$,, Fields/binary>> =
+                << <<$,, Table/binary, $., (Module:'$meta'({db_alias, F}))/binary>>
+                    || F <- RFields>>,
             Sql =
                 <<"SELECT ", Fields/binary,
                   " FROM ", Table/binary,
@@ -60,12 +88,31 @@ find(PoolName, Module, Query, QueryArgs) ->
                   fun(F, A) -> F(A) end,
                   ArgFuns,
                   QueryArgs),
-            tq_postgres_driver:'query'(PoolName, Sql, Args, Constructor);
+            Constructor = Module:constructor(RFields),
+            {Sql, Args, Constructor};
         {error, _Reason} = Err ->
             Err
     end.
 
-delete(PoolName, Module, IndexFV) ->
+delete(PoolName, Module, IndexFV)  when is_atom(PoolName) or is_binary(PoolName) ->
+    {Sql, Args, Constructor} = delete_params(Module, IndexFV),
+    Result = tq_postgres_driver:'query'(PoolName, Sql, Args, Constructor),
+    delete_result(Result);
+
+delete(Connection, Module, IndexFV) when is_pid(Connection) ->
+    {Sql, Args, Constructor} = delete_params(Module, IndexFV),
+    Result = query_with_escape(Connection, Sql, Args, Constructor),
+    delete_result(Result).
+
+delete_result(Result) ->
+    case Result of
+        {ok, _} ->
+            ok;
+        {error, _Reason} = Err ->
+            Err
+    end.
+
+delete_params(Module, IndexFV) ->
     Table = Module:'$meta'(table),
     {<<" AND ", Where/binary>>, _} =
         each_with(
@@ -79,14 +126,27 @@ delete(PoolName, Module, IndexFV) ->
           " WHERE ", Where/binary, ";">>,
     Args = [{Module:'$meta'({db_type, F}), V} || {F, V} <- IndexFV],
     Constructor = fun(A) -> A end,
-    case tq_postgres_driver:'query'(PoolName, Sql, Args, Constructor) of
-        {ok, _} ->
-            ok;
+    {Sql, Args, Constructor}.
+
+insert(PoolName, Module, ChangedFV) when is_atom(PoolName) or is_binary(PoolName) ->
+    {Sql, Args, Constructor} = insert_params(Module, ChangedFV),
+    Result = tq_postgres_driver:'query'(PoolName, Sql, Args, Constructor),
+    insert_result(Result);
+
+insert(Connection, Module, ChangedFV) when is_pid(Connection) ->
+    {Sql, Args, Constructor} = insert_params(Module, ChangedFV),
+    Result = query_with_escape(Connection, Sql, Args, Constructor),
+    insert_result(Result).
+
+insert_result(Result) ->
+    case Result of
+        {ok, 1, [Model]} ->
+            {ok, Model};
         {error, _Reason} = Err ->
             Err
     end.
 
-insert(PoolName, Module, ChangedFV) ->
+insert_params(Module, ChangedFV) ->
     Table = Module:'$meta'(table),
     RFields = Module:'$meta'({db_fields, r}),
     <<$,, Returning/binary>> =
@@ -107,14 +167,29 @@ insert(PoolName, Module, ChangedFV) ->
             "(", Fields/binary, ")",
             " VALUES (", Values/binary, ")",
             " RETURNING ", Returning/binary, ";">>,
-    case tq_postgres_driver:'query'(PoolName, Sql, Args, Constructor) of
+    {Sql, Args, Constructor}.
+
+update(PoolName, Module, ChangedFV, IndexFV)  when is_atom(PoolName) or is_binary(PoolName) ->
+    {Sql, Args, Constructor} = update_params(Module, ChangedFV, IndexFV),
+    Result = tq_postgres_driver:'query'(PoolName, Sql, Args, Constructor),
+    update_result(Result);
+
+update(Connection, Module, ChangedFV, IndexFV) when is_pid(Connection) ->
+    {Sql, Args, Constructor} = update_params(Module, ChangedFV, IndexFV),
+    Result =  query_with_escape(Connection, Sql, Args, Constructor),
+    update_result(Result).
+
+update_result(Result) ->
+    case Result of
         {ok, 1, [Model]} ->
             {ok, Model};
+        {ok, 0, []} ->
+            {error, undefined};
         {error, _Reason} = Err ->
             Err
     end.
 
-update(PoolName, Module, ChangedFV, IndexesFV) ->
+update_params(Module, ChangedFV, IndexesFV) ->
     Table = Module:'$meta'(table),
     RFields = Module:'$meta'({db_fields, r}),
     <<$,, Returning/binary>> =
@@ -142,14 +217,7 @@ update(PoolName, Module, ChangedFV, IndexesFV) ->
           " WHERE ", Where/binary,
           " RETURNING ", Returning/binary, ";">>,
     Args = DataArgs ++ WhereArgs,
-    case tq_postgres_driver:'query'(PoolName, Sql, Args, Constructor) of
-        {ok, 1, [Model]} ->
-            {ok, Model};
-        {ok, 0, []} ->
-            {error, undefined};
-        {error, _Reason} = Err ->
-            Err
-    end.
+    {Sql, Args, Constructor}.
 
 %% =============================================================================
 %%% Internal functions
@@ -162,3 +230,11 @@ each_with(_Fun, Index, Acc, []) ->
 each_with(Fun, Index, Acc, [H|T]) ->
     Acc2 = Fun(H, Index, Acc),
     each_with(Fun, Index+1, Acc2, T).
+
+query_with_escape(Connection, Sql, Args, Constructor) ->
+    case tq_postgres_driver_utils:escape_args(Args) of
+        {ok, EscapedArgs} ->
+            tq_postgres_driver_db_query:query(Connection, Sql, EscapedArgs, Constructor);
+        {error, _Reason} = Err ->
+            Err
+    end.

--- a/src/tq_postgres_driver_runtime.erl
+++ b/src/tq_postgres_driver_runtime.erl
@@ -20,12 +20,12 @@ get(PoolName, Module, IndexFV) ->
         << <<$,, (Module:'$meta'({db_alias, F}))/binary>> || F <- RFields>>,
     Constructor = Module:constructor(RFields),
 
-    {<<$,, Where/binary>>, _} =
+    {<<" AND ", Where/binary>>, _} =
         each_with(
           fun({F, _V}, I, Acc) ->
                   Alias = Module:'$meta'({db_alias, F}),
                   BinIndex = integer_to_binary(I),
-                  <<Acc/binary, $,, Alias/binary, " = $", BinIndex/binary>>
+                  <<Acc/binary, " AND ", Alias/binary, " = $", BinIndex/binary>>
           end, <<>>, IndexFV),
 
     Sql =

--- a/src/tq_postgres_driver_utils.erl
+++ b/src/tq_postgres_driver_utils.erl
@@ -1,0 +1,115 @@
+%%%-------------------------------------------------------------------
+%%% @author isergey
+%%% @copyright (C) 2015, <COMPANY>
+%%% @doc
+%%%
+%%% @end
+%%% Created : 02. Feb 2015 1:05 PM
+%%%-------------------------------------------------------------------
+-module(tq_postgres_driver_utils).
+-author("isergey").
+
+%% API
+-export([escape_args/1]).
+
+%% =============================================================================
+%% Internal functions
+%% =============================================================================
+
+escape_args(Args) ->
+    error_writer_map(fun escape_arg/1, Args).
+
+escape_arg({_Name, null}) ->
+    {ok, null};
+escape_arg({Name, Arg}) when
+    Name =:= smallint;
+    Name =:= int2;
+    Name =:= integer;
+    Name =:= int4;
+    Name =:= bigint;
+    Name =:= int8
+    ->
+    case Arg of
+        Bin when is_binary(Bin) ->
+            try
+                {ok, binary_to_integer(Bin)}
+            catch _:_ ->
+                {error, bad_arg}
+            end;
+        Int when is_integer(Int) ->
+            {ok, Int};
+        _ ->
+            {error, bad_arg}
+    end;
+escape_arg({Name, Arg}) when
+    Name =:= real;
+    Name =:= float4;
+    Name =:= float8 ->
+    case Arg of
+        Bin when is_binary(Bin) ->
+            try
+                {ok, binary_to_integer(Bin)}
+            catch _:_ ->
+                try
+                    {ok, binary_to_float(Bin)}
+                catch _:_ ->
+                    {error, bad_arg}
+                end
+            end;
+        Int when is_integer(Int) ->
+            {ok, Int};
+        Float when is_float(Float) ->
+            {ok, Float};
+        _ ->
+            {error, bad_arg}
+    end;
+escape_arg({Name, Arg}) when
+    Name =:= string;
+    Name =:= text;
+    Name =:= varchar ->
+    case Arg of
+        Bin when is_binary(Bin) ->
+            {ok, Bin};
+        _ ->
+            {error, bad_arg}
+    end;
+escape_arg({date, Arg}) ->
+    case Arg of
+        {_Y, _M, _D} ->
+            {ok, Arg};
+        _ ->
+            {error, bad_arg}
+    end;
+escape_arg({datetime, Arg}) ->
+    case Arg of
+        {{_Y, _M, _D}, {_Hh, _Mm, _Ss}} ->
+            {ok, Arg};
+        _ ->
+            {error, bad_arg}
+    end;
+escape_arg({Name, Arg}) when
+    Name =:= boolean;
+    Name =:= bool ->
+    case Arg of
+        true ->
+            {ok, true};
+        false ->
+            {ok, false};
+        _ ->
+            {error, bad_arg}
+    end.
+
+error_writer_map(Fun, List) ->
+    error_writer_map(Fun, List, [], []).
+
+error_writer_map(_Fun, [], Acc, []) ->
+    {ok, lists:reverse(Acc)};
+error_writer_map(_Fun, [], _Acc, Errors) ->
+    {error, {type_mismatch, lists:reverse(Errors)}};
+error_writer_map(Fun, [{Type, Value}=H|T], Acc, Errors) ->
+    case Fun(H) of
+        {ok, R} ->
+            error_writer_map(Fun, T, [R|Acc], Errors);
+        {error, R} ->
+            error_writer_map(Fun, T, Acc, [{R, [Type, Value]}|Errors])
+    end.


### PR DESCRIPTION
Предлагаю расширить драйвер для использования транзакций.
В последних 2 комитах реализация, в первых исправлены некоторые ошибки. 

Запросы можно делать, к примеру, так:
    Driver = tq_db:get_pool_driver(db),
    Transaction =
        fun (Connection) ->
            do([error_m ||
                %% some valid update
                tq_postgres_driver:update(Connection, db_user, [{name, <<"Ivan">>}], [{id, 550}]),
                %% some invalid update or e.g. disconnect with db
                tq_postgres_driver:update(Connection, db_profile, [{id, 550}, {profile_info, <<"somedata">>}], [{id, 558}])
            ])
        end,
    Driver:transaction(db, Transaction).
Из-за второго запроса первый также не внесет изменения в базу. Подход "все или ничего"

Конечная цель: сделать в моделях tq_db возможность использовать транзакции. 
